### PR TITLE
Add initial Blazor project structure

### DIFF
--- a/BlazorTerminal.ComponentLib/BlazorTerminal.ComponentLib.csproj
+++ b/BlazorTerminal.ComponentLib/BlazorTerminal.ComponentLib.csproj
@@ -1,0 +1,7 @@
+<Project Sdk="Microsoft.NET.Sdk.Razor">
+  <PropertyGroup>
+    <TargetFramework>net8.0</TargetFramework>
+    <Nullable>enable</Nullable>
+    <ImplicitUsings>enable</ImplicitUsings>
+  </PropertyGroup>
+</Project>

--- a/BlazorTerminal.ComponentLib/TerminalControl.razor
+++ b/BlazorTerminal.ComponentLib/TerminalControl.razor
@@ -1,0 +1,3 @@
+<div class="blazor-terminal">
+    Terminal placeholder
+</div>

--- a/BlazorTerminal.ComponentLib/TerminalControl.razor.css
+++ b/BlazorTerminal.ComponentLib/TerminalControl.razor.css
@@ -1,0 +1,3 @@
+.blazor-terminal {
+    font-family: monospace;
+}

--- a/BlazorTerminal.ComponentLib/_Imports.razor
+++ b/BlazorTerminal.ComponentLib/_Imports.razor
@@ -1,0 +1,2 @@
+@using Microsoft.AspNetCore.Components
+@using Microsoft.AspNetCore.Components.Web

--- a/BlazorTerminal.TestApp/App.razor
+++ b/BlazorTerminal.TestApp/App.razor
@@ -1,0 +1,9 @@
+@using BlazorTerminal.ComponentLib
+<Router AppAssembly="typeof(Program).Assembly">
+    <Found Context="routeData">
+        <RouteView RouteData="routeData" />
+    </Found>
+    <NotFound>
+        <p>Page not found</p>
+    </NotFound>
+</Router>

--- a/BlazorTerminal.TestApp/BlazorTerminal.TestApp.csproj
+++ b/BlazorTerminal.TestApp/BlazorTerminal.TestApp.csproj
@@ -1,0 +1,10 @@
+<Project Sdk="Microsoft.NET.Sdk.BlazorWebAssembly">
+  <PropertyGroup>
+    <TargetFramework>net8.0</TargetFramework>
+    <Nullable>enable</Nullable>
+    <ImplicitUsings>enable</ImplicitUsings>
+  </PropertyGroup>
+  <ItemGroup>
+    <ProjectReference Include="../BlazorTerminal.ComponentLib/BlazorTerminal.ComponentLib.csproj" />
+  </ItemGroup>
+</Project>

--- a/BlazorTerminal.TestApp/Pages/Index.razor
+++ b/BlazorTerminal.TestApp/Pages/Index.razor
@@ -1,0 +1,5 @@
+@page "/"
+
+<h3>Test Terminal</h3>
+
+<TerminalControl />

--- a/BlazorTerminal.TestApp/Program.cs
+++ b/BlazorTerminal.TestApp/Program.cs
@@ -1,0 +1,7 @@
+using Microsoft.AspNetCore.Components.Web;
+using Microsoft.AspNetCore.Components.WebAssembly.Hosting;
+
+var builder = WebAssemblyHostBuilder.CreateDefault(args);
+builder.RootComponents.Add<App>("#app");
+
+await builder.Build().RunAsync();

--- a/BlazorTerminal.TestApp/_Imports.razor
+++ b/BlazorTerminal.TestApp/_Imports.razor
@@ -1,0 +1,4 @@
+@using System.Net.Http
+@using Microsoft.AspNetCore.Components
+@using Microsoft.AspNetCore.Components.Web
+@using BlazorTerminal.ComponentLib

--- a/BlazorTerminal.TestApp/wwwroot/index.html
+++ b/BlazorTerminal.TestApp/wwwroot/index.html
@@ -1,0 +1,11 @@
+<!DOCTYPE html>
+<html>
+<head>
+    <meta charset="utf-8" />
+    <title>BlazorTerminal.TestApp</title>
+</head>
+<body>
+    <div id="app">Loading...</div>
+    <script src="_framework/blazor.webassembly.js"></script>
+</body>
+</html>

--- a/BlazorTerminal.sln
+++ b/BlazorTerminal.sln
@@ -1,0 +1,27 @@
+Microsoft Visual Studio Solution File, Format Version 12.00
+# Visual Studio Version 17
+VisualStudioVersion = 17.8.0
+MinimumVisualStudioVersion = 10.0.40219.1
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "BlazorTerminal.ComponentLib", "BlazorTerminal.ComponentLib/BlazorTerminal.ComponentLib.csproj", "{a868ed5c-76ff-4e42-803c-18db3bd6e988}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "BlazorTerminal.TestApp", "BlazorTerminal.TestApp/BlazorTerminal.TestApp.csproj", "{b8997834-7e8c-422c-a1e9-a01ea843a77c}"
+EndProject
+Global
+    GlobalSection(SolutionConfigurationPlatforms) = preSolution
+        Debug|Any CPU = Debug|Any CPU
+        Release|Any CPU = Release|Any CPU
+    EndGlobalSection
+    GlobalSection(ProjectConfigurationPlatforms) = postSolution
+        {a868ed5c-76ff-4e42-803c-18db3bd6e988}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+        {a868ed5c-76ff-4e42-803c-18db3bd6e988}.Debug|Any CPU.Build.0 = Debug|Any CPU
+        {a868ed5c-76ff-4e42-803c-18db3bd6e988}.Release|Any CPU.ActiveCfg = Release|Any CPU
+        {a868ed5c-76ff-4e42-803c-18db3bd6e988}.Release|Any CPU.Build.0 = Release|Any CPU
+        {b8997834-7e8c-422c-a1e9-a01ea843a77c}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+        {b8997834-7e8c-422c-a1e9-a01ea843a77c}.Debug|Any CPU.Build.0 = Debug|Any CPU
+        {b8997834-7e8c-422c-a1e9-a01ea843a77c}.Release|Any CPU.ActiveCfg = Release|Any CPU
+        {b8997834-7e8c-422c-a1e9-a01ea843a77c}.Release|Any CPU.Build.0 = Release|Any CPU
+    EndGlobalSection
+    GlobalSection(SolutionProperties) = preSolution
+        HideSolutionNode = FALSE
+    EndGlobalSection
+EndGlobal


### PR DESCRIPTION
## Summary
- add solution file for `BlazorTerminal`
- add Blazor component library `BlazorTerminal.ComponentLib`
- add test Blazor WebAssembly project `BlazorTerminal.TestApp` referencing the library
- provide placeholder `TerminalControl` component and sample usage

## Testing
- `dotnet --version` *(fails: command not found)*