### PR TITLE
Add core terminal state models

### DIFF
--- a/BlazorTerminal.ComponentLib/Models/CursorShape.cs
+++ b/BlazorTerminal.ComponentLib/Models/CursorShape.cs
@@ -1,0 +1,12 @@
+namespace BlazorTerminal.ComponentLib.Models
+{
+    /// <summary>
+    /// Shapes that the terminal cursor can take.
+    /// </summary>
+    public enum CursorShape
+    {
+        Block,
+        Underline,
+        Bar
+    }
+}

--- a/BlazorTerminal.ComponentLib/Models/CursorState.cs
+++ b/BlazorTerminal.ComponentLib/Models/CursorState.cs
@@ -1,0 +1,28 @@
+namespace BlazorTerminal.ComponentLib.Models
+{
+    /// <summary>
+    /// Represents the current state of the terminal cursor.
+    /// </summary>
+    public class CursorState
+    {
+        /// <summary>
+        /// Zero-based row position of the cursor.
+        /// </summary>
+        public int Row { get; set; }
+
+        /// <summary>
+        /// Zero-based column position of the cursor.
+        /// </summary>
+        public int Column { get; set; }
+
+        /// <summary>
+        /// Whether the cursor is visible.
+        /// </summary>
+        public bool Visible { get; set; } = true;
+
+        /// <summary>
+        /// The shape of the cursor when rendered.
+        /// </summary>
+        public CursorShape Shape { get; set; } = CursorShape.Block;
+    }
+}

--- a/BlazorTerminal.ComponentLib/Models/ScreenBuffer.cs
+++ b/BlazorTerminal.ComponentLib/Models/ScreenBuffer.cs
@@ -1,0 +1,62 @@
+using System;
+
+namespace BlazorTerminal.ComponentLib.Models
+{
+    /// <summary>
+    /// Represents the 2D grid of cells that make up the terminal screen.
+    /// </summary>
+    public class ScreenBuffer
+    {
+        private readonly TerminalCell[,] _cells;
+
+        /// <summary>
+        /// Number of rows in the buffer.
+        /// </summary>
+        public int Rows { get; }
+
+        /// <summary>
+        /// Number of columns in the buffer.
+        /// </summary>
+        public int Columns { get; }
+
+        /// <summary>
+        /// Access cells by row and column.
+        /// </summary>
+        public TerminalCell this[int row, int column]
+        {
+            get => _cells[row, column];
+            set => _cells[row, column] = value;
+        }
+
+        /// <summary>
+        /// Creates a new screen buffer.
+        /// </summary>
+        /// <param name="rows">Number of rows.</param>
+        /// <param name="columns">Number of columns.</param>
+        public ScreenBuffer(int rows, int columns)
+        {
+            if (rows <= 0) throw new ArgumentOutOfRangeException(nameof(rows));
+            if (columns <= 0) throw new ArgumentOutOfRangeException(nameof(columns));
+
+            Rows = rows;
+            Columns = columns;
+            _cells = new TerminalCell[rows, columns];
+            Clear();
+        }
+
+        /// <summary>
+        /// Fill the entire buffer with the supplied cell or blanks.
+        /// </summary>
+        public void Clear(TerminalCell? fillCell = null)
+        {
+            var cell = fillCell ?? new TerminalCell(' ');
+            for (int r = 0; r < Rows; r++)
+            {
+                for (int c = 0; c < Columns; c++)
+                {
+                    _cells[r, c] = cell;
+                }
+            }
+        }
+    }
+}

--- a/BlazorTerminal.ComponentLib/Models/TerminalCell.cs
+++ b/BlazorTerminal.ComponentLib/Models/TerminalCell.cs
@@ -1,0 +1,24 @@
+namespace BlazorTerminal.ComponentLib.Models
+{
+    /// <summary>
+    /// Represents a single character cell on the terminal screen.
+    /// </summary>
+    public struct TerminalCell
+    {
+        /// <summary>
+        /// The character displayed in the cell.
+        /// </summary>
+        public char Character { get; set; }
+
+        /// <summary>
+        /// Styling applied to the character.
+        /// </summary>
+        public TerminalStyle Style { get; set; }
+
+        public TerminalCell(char character)
+        {
+            Character = character;
+            Style = new TerminalStyle();
+        }
+    }
+}

--- a/BlazorTerminal.ComponentLib/Models/TerminalStyle.cs
+++ b/BlazorTerminal.ComponentLib/Models/TerminalStyle.cs
@@ -1,0 +1,34 @@
+namespace BlazorTerminal.ComponentLib.Models
+{
+    /// <summary>
+    /// Encapsulates basic styling information for a terminal cell.
+    /// Colors are represented as CSS strings (e.g. "#ffffff" or "red").
+    /// </summary>
+    public class TerminalStyle
+    {
+        /// <summary>
+        /// Foreground text color.
+        /// </summary>
+        public string ForegroundColor { get; set; } = "#ffffff";
+
+        /// <summary>
+        /// Background text color.
+        /// </summary>
+        public string BackgroundColor { get; set; } = "#000000";
+
+        /// <summary>
+        /// Additional text attributes like bold or underline.
+        /// </summary>
+        public TextAttribute Attributes { get; set; } = TextAttribute.None;
+
+        /// <summary>
+        /// Creates a deep copy of the style.
+        /// </summary>
+        public TerminalStyle Clone() => new()
+        {
+            ForegroundColor = ForegroundColor,
+            BackgroundColor = BackgroundColor,
+            Attributes = Attributes
+        };
+    }
+}

--- a/BlazorTerminal.ComponentLib/Models/TextAttribute.cs
+++ b/BlazorTerminal.ComponentLib/Models/TextAttribute.cs
@@ -1,0 +1,17 @@
+using System;
+
+namespace BlazorTerminal.ComponentLib.Models
+{
+    /// <summary>
+    /// Flags representing common text attributes for a terminal cell.
+    /// </summary>
+    [Flags]
+    public enum TextAttribute
+    {
+        None = 0,
+        Bold = 1 << 0,
+        Italic = 1 << 1,
+        Underline = 1 << 2,
+        Inverse = 1 << 3
+    }
+}


### PR DESCRIPTION
## Summary
- add basic terminal models in BlazorTerminal.ComponentLib
- include terminal cell, screen buffer, cursor shape and state, styles

## Testing
- `MSBUILDDISABLETERMINALLOG=1 dotnet build BlazorTerminal.sln -v minimal` *(fails: Unable to load the service index for source https://api.nuget.org/v3/index.json)*